### PR TITLE
Get rid of deprecation message

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-      "formidable": "1.0.14"
+      "formidable": "1.0.17"
     , "gridfs-stream": "0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Was getting
    Error: (node) Buffer.write(string, encoding, offset, length) is deprecated. Use write(string[, offset[, length]][, encoding]) instead.
