### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#gridform
+# gridform
 ======================
 
 [Formidable](https://github.com/felixge/node-formidable) streams uploads to the file system by default. If you're using GridFS to store files you'll then need to turn around and copy them off of the file system. Using `gridform` removes this burden.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
